### PR TITLE
Fix chiseled sandstone entry

### DIFF
--- a/data/collector/advancements/collections/ground/sand/sandstone/root.json
+++ b/data/collector/advancements/collections/ground/sand/sandstone/root.json
@@ -25,7 +25,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:coarse_dirt"
+            "item": "minecraft:chiseled_sandstone"
           }
         ]
       }


### PR DESCRIPTION
Smooth Operator achievement was looking for coarse dirt instead of chiseled sandstone.